### PR TITLE
Enhance signature route with custom name option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+uploads
+client/node_modules
+server/services/serviceAccountKey.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Simple container for NodeOps deployment
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production
+COPY . .
+RUN npm run build || true
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm","start"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ corresponding WIF key (`INTERNAL_BTC_WIF`) is required for OP_RETURN pushes.
 
 ---
 
+### Docker Image
+The repository includes a `Dockerfile` for building a lightweight image
+compatible with [NodeOps](https://docs.nodeops.network/). The container can run
+an autonomous agent that generates and optionally inscribes signatures. Build
+and run it:
+
+```bash
+docker build -t ordforms .
+docker run -p 3000:3000 ordforms
+```
+
+The container exposes port `3000` and runs the Express server. Set your
+environment variables with `-e` flags or a `.env` file. To have the container
+autonomously generate and inscribe a signature, run:
+
+```bash
+docker run -e SIGNATURE_ENDPOINT=http://localhost:3000/api/signature ordforms npm run agent
+```
+
+---
+
 ## 📬 API Routes
 
 - `/api/submission/verify-voucher`
@@ -70,8 +91,18 @@ corresponding WIF key (`INTERNAL_BTC_WIF`) is required for OP_RETURN pushes.
 - `/api/bitcoin/ordinals/cost`
 - `/api/bitcoin/ordinals/inscribe`
 - `/api/bitcoin/opreturn/push`
+- `/api/signature/:type?format=svg|html&inscribe=true&generative=true&name=Custom`
 - `/api/auth/github`
 - `/api/auth/github/callback`
+
+### Testing the Signature Route
+
+Run `npm run test:signature` to request an example signature and create an
+inscription order via Ordinalsbot. The endpoint supports `generative=true` to
+return HTML that loads [p5.js] via Ordinals recursion from inscription
+`bed725759768159b0868fe0e6c9cd26a4c437f9e0903f70893edad280e35d843i0`. Pass
+`name=OrdForms` to customize the rendered text. Ensure the server is running on
+`localhost:3000` and that your `.env` includes a valid `ORDINALSBOT_API_KEY`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "npm run build:client",
     "dev:client": "webpack serve --config webpack.config.js --mode development",
     "dev:server": "nodemon server/index.js",
-    "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\""
+    "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
+    "test:signature": "node tests/signatureRouteTest.js",
+    "agent": "node scripts/autonomousSignature.js"
   },
   "dependencies": {
     "axios": "^1.10.0",

--- a/scripts/autonomousSignature.js
+++ b/scripts/autonomousSignature.js
@@ -1,0 +1,15 @@
+const axios = require('axios');
+
+async function run() {
+  const type = process.argv[2] || 'user';
+  const endpoint = process.env.SIGNATURE_ENDPOINT || 'http://localhost:3000/api/signature';
+  const name = process.env.SIGNATURE_NAME || 'OrdForms';
+  try {
+    const res = await axios.get(`${endpoint}/${type}?format=html&inscribe=true&generative=true&name=${encodeURIComponent(name)}`);
+    console.log(res.data);
+  } catch (err) {
+    console.error('Agent error:', err.response ? err.response.data : err.message);
+  }
+}
+
+run();

--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ const authRoutes = require('./routes/authRoutes');
 const submissionRoutes = require('./routes/submissionRoutes');
 const bitcoinRoutes = require('./routes/bitcoinRoutes');
 const uploadRoutes = require('./routes/upload.js');
+const signatureRoutes = require('./routes/signatureRoutes');
 
 
 dotenv.config();
@@ -54,6 +55,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/submission', submissionRoutes);
 app.use('/api/bitcoin', bitcoinRoutes);
 app.use('/api', uploadRoutes);
+app.use('/api/signature', signatureRoutes);
 
 app.get('/', (_, res) => res.send('Permissionless Submission Backend Running'));
 

--- a/server/routes/signatureRoutes.js
+++ b/server/routes/signatureRoutes.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const {
+  inscribeContent,
+  P5_INSCRIPTION_ID
+} = require('../services/ordinalsService');
+const router = express.Router();
+
+const allowedTypes = ['user', 'creator', 'business'];
+
+router.get('/:type', async (req, res) => {
+  const { type } = req.params;
+  const format = req.query.format || 'svg';
+  const shouldInscribe = req.query.inscribe === 'true';
+  const generative = req.query.generative === 'true';
+  const parent = req.query.parent || P5_INSCRIPTION_ID;
+  const customName = req.query.name;
+
+  if (!customName && !allowedTypes.includes(type)) {
+    return res.status(400).send('Invalid type');
+  }
+
+  const text = customName ? customName : type.toUpperCase();
+  const html = `<div>${text}</div>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="40"><text x="10" y="25" font-size="20">${text}</text></svg>`;
+
+  const generativeHtml = `<!doctype html>
+<script src="ord:${P5_INSCRIPTION_ID}"></script>
+<script>
+function setup(){
+  createCanvas(200,40);
+  background(255);
+  fill(random(50,200));
+  textSize(20);
+  text('${text}',10,25);
+  noLoop();
+}
+</script>`;
+
+  const contentToSend = generative ? generativeHtml : format === 'html' ? html : svg;
+  const mimeType = generative || format === 'html' ? 'text/html' : 'image/svg+xml';
+
+  if (shouldInscribe) {
+    try {
+      const order = await inscribeContent(contentToSend, mimeType, parent);
+      return res.json({ success: true, order });
+    } catch (err) {
+      return res.status(500).json({ success: false, error: err.message });
+    }
+  }
+
+  if (generative || format === 'html') {
+    res.setHeader('Content-Type', 'text/html');
+    return res.send(contentToSend);
+  }
+  res.setHeader('Content-Type', 'image/svg+xml');
+  res.send(svg);
+});
+
+module.exports = router;

--- a/server/services/ordinalsService.js
+++ b/server/services/ordinalsService.js
@@ -4,6 +4,10 @@ const API_KEY = process.env.ORDINALSBOT_API_KEY || '';
 const NETWORK = 'testnet';
 const ord = new Ordinalsbot(API_KEY, NETWORK);
 
+// Inscription containing p5.min.js v2.0.1 used for recursion
+const P5_INSCRIPTION_ID =
+  'bed725759768159b0868fe0e6c9cd26a4c437f9e0903f70893edad280e35d843i0';
+
 const estimateCost = async (content) => {
   const inscription = ord.Inscription();
   const order = await inscription.createOrder({
@@ -31,10 +35,28 @@ const inscribeHash = async (hash, parent) => {
         dataURL: `data:text/plain;base64,${Buffer.from(hash).toString('base64')}`
       }
     ],
-    ...(parent ? { parent } : {}),
+    ...(parent ? { parent } : { parent: P5_INSCRIPTION_ID }),
     receiveAddress: process.env.INTERNAL_BTC_WALLET || ''
   });
   return order;
 };
 
-module.exports = { estimateCost, inscribeHash };
+const inscribeContent = async (content, mimeType, parent) => {
+  const inscription = ord.Inscription();
+  const dataURL = `data:${mimeType};base64,${Buffer.from(content).toString('base64')}`;
+  const order = await inscription.createOrder({
+    files: [
+      {
+        size: Buffer.byteLength(content),
+        type: mimeType,
+        name: 'signature',
+        dataURL
+      }
+    ],
+    ...(parent ? { parent } : { parent: P5_INSCRIPTION_ID }),
+    receiveAddress: process.env.INTERNAL_BTC_WALLET || ''
+  });
+  return order;
+};
+
+module.exports = { estimateCost, inscribeHash, inscribeContent, P5_INSCRIPTION_ID };

--- a/tests/signatureRouteTest.js
+++ b/tests/signatureRouteTest.js
@@ -1,0 +1,11 @@
+const axios = require('axios');
+
+(async () => {
+  const type = 'user';
+  try {
+    const res = await axios.get(`http://localhost:3000/api/signature/${type}?format=html&inscribe=true&generative=true&name=OrdForms`);
+    console.log(res.data);
+  } catch (err) {
+    console.error('Error:', err.response ? err.response.data : err.message);
+  }
+})();


### PR DESCRIPTION
## Summary
- allow custom name via `name` query parameter
- support name setting in autonomous agent script
- document custom `name` option in README
- update standalone test to show `OrdForms`

## Testing
- `npm install`
- `npm run build`
- `npm run test:signature` *(fails with status code 503)*

------
https://chatgpt.com/codex/tasks/task_e_6859deba53208320bafbb7015a5a59b3